### PR TITLE
fix: dispose-safety data leak, allocating equality, and false claims

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,50 +1,80 @@
 name: Publish to NuGet
 
+# Version comes from <VersionPrefix> in Directory.Build.props, never from a
+# hand-typed input, so the published version is always recorded in git.
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to publish (e.g., 1.0.0)"
-        required: true
-        type: string
+      dry_run:
+        description: "Build and pack without publishing"
+        type: boolean
+        default: true
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      id-token: write # NuGet trusted publishing
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --configuration Release --no-restore /p:Version=${{ github.event.inputs.version }}
-
-      - name: Pack packages
-        run: dotnet pack Verdict.sln --configuration Release --output ./nupkgs /p:Version=${{ github.event.inputs.version }}
-
-      - name: Check for NuGet API Key
+      - name: Read version from source
+        id: version
         run: |
-          if [ -z "${{ secrets.NUGET_API_KEY }}" ]; then
-            echo "::error::NUGET_API_KEY secret is not set. Please add it to your repository settings."
+          VERSION=$(grep -oP '(?<=<VersionPrefix>)[^<]+' Directory.Build.props)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version from Directory.Build.props: $VERSION"
+
+      - name: Confirm tag matches the version in source
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ "$TAG" != "v$VERSION" ]; then
+            echo "Tag $TAG does not match VersionPrefix $VERSION" >&2
             exit 1
           fi
 
-      - name: Publish to NuGet
-        run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - run: dotnet restore
 
-      - name: Create Git tag
+      - run: dotnet build --configuration Release --no-restore
+
+      # A package must never ship without its tests having run.
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+      - name: Pack
+        run: dotnet pack Verdict.sln --configuration Release --no-build --output ./nupkgs
+
+      - name: List artifacts
+        run: ls -la ./nupkgs
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nupkgs
+          path: ./nupkgs/*
+
+      - name: Publish
+        if: ${{ !inputs.dry_run }}
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git tag -a "v${{ github.event.inputs.version }}" -m "Release v${{ github.event.inputs.version }}"
-          git push origin "v${{ github.event.inputs.version }}"
+          if [ -z "${{ secrets.NUGET_API_KEY }}" ]; then
+            echo "::error::NUGET_API_KEY secret is not set." && exit 1
+          fi
+          dotnet nuget push ./nupkgs/*.nupkg \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-08-07
+
+### Fixed (Critical)
+
+- **`ErrorCollection` could read another caller's data after disposal.** `Dispose()`
+  returns the buffer to `ArrayPool.Shared` but the struct kept the reference, so
+  `Count`, the indexer, `AsSpan()`, `First()` and `ToArray()` continued to work and
+  returned whatever the next renter wrote. Across requests that is one caller
+  reading another's errors. All accessors now throw `ObjectDisposedException`.
+  Because `ErrorCollection` is a struct, disposing any copy invalidates them all,
+  which is now enforced rather than silent.
+
+### Fixed
+
+- **`Result<T>` and `Result` allocated on every equality comparison.** Neither
+  overrode `Equals` or `GetHashCode`, so both fell through to reflection-based
+  `ValueType.Equals`: 320 bytes per call, in a library whose guarantee is zero
+  allocation. Any `HashSet`, dictionary key, `Contains` or `Distinct` paid it.
+  Both now implement `IEquatable<>` with `==`, `!=` and `GetHashCode`. Measured
+  320,000 bytes to 0 over 1,000 comparisons.
+- **Corrected the thread-safety claim.** The package description, README and XML
+  docs described `Result<T>` as thread-safe. It is immutable and safe to read
+  concurrently, but it is 32-48 bytes, so concurrently reassigning a shared field
+  can tear. A test observed 256,854 torn reads in 1.5 seconds. The docs now state
+  the actual guarantee.
+- **Corrected the GC pressure figure.** The README claimed 25 GB/sec saved at
+  100k req/sec. From its own stated FluentResults allocation rate the correct
+  figure is 18-38 MB/sec, roughly 1000x smaller.
+- **Malformed XML doc comments** in `ResultExtensions` never compiled, because
+  documentation generation had never been enabled.
+
+### Added
+
+- **Trimming and Native AOT support.** All packages except `Verdict.Json` are
+  `IsTrimmable` and `IsAotCompatible` and publish clean under `PublishAot`.
+  `ResultJsonConverter<T>` now resolves `JsonTypeInfo` from the caller's options
+  rather than calling reflection-based `JsonSerializer`, and
+  `AddVerdictConverter<T>()` / `AddVerdictResultConverter()` give an AOT-safe
+  registration path. The convenience factory is annotated `[RequiresDynamicCode]`.
+  Verified with a real `PublishAot` binary.
+- **XML documentation now ships.** `GenerateDocumentationFile` was not set on any
+  project, so every `///` comment was discarded at pack time and consumers got no
+  IntelliSense.
+- **SourceLink, symbol packages and deterministic builds** via a new
+  `Directory.Build.props`, which is also the single source of the version.
+- `ErrorCollection.IsDisposed`.
+
+### Changed
+
+- **The publish workflow now runs the tests** before packing. It previously went
+  restore, build, pack, push.
+- **The release version comes from `Directory.Build.props`**, not a hand-typed
+  workflow input, and the tag is checked against it. Previously the published
+  version existed nowhere in source: `csproj` said 2.3.0 while nuget.org had 2.4.0.
+- `TreatWarningsAsErrors` on all shipping projects.
+
+### Known limitations
+
+- `Error.Exception` is a public property, so System.Text.Json's source generator
+  descends into `System.Exception` and emits two `IL2026` warnings for
+  `TargetSite`. Harmless at runtime; `ErrorJsonConverter` never serializes it.
+  Replacing the property with a method is planned for the next major version.
+
 ## [2.4.0] - 2026-03-02
 
 ### Fixed (Critical)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,59 @@
+<Project>
+
+  <!-- Shared build and packaging settings. Applies to every project in the
+       solution; package-specific metadata stays in each csproj. -->
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+
+    <!-- Single source of truth for the release version. The publish workflow
+         reads this rather than taking a hand-typed input, so what shipped is
+         always recorded in git. -->
+    <VersionPrefix>2.5.0</VersionPrefix>
+  </PropertyGroup>
+
+  <!-- Everything below applies only to the shipping libraries. -->
+  <PropertyGroup Condition="'$(IsPackable)' != 'false' AND $(MSBuildProjectDirectory.Contains('src'))">
+    <Authors>Baryo.Dev</Authors>
+    <Company>Baryo.Dev</Company>
+    <Copyright>Copyright (c) Baryo.Dev</Copyright>
+    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!-- Ship the XML docs. Without this every /// comment in the codebase is
+         discarded at pack time and consumers get no IntelliSense. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- SourceLink: lets consumers step into library code from their debugger. -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <!-- Reproducible builds. ContinuousIntegrationBuild normalises paths so the
+         same source produces a byte-identical package. -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!-- Trimming and Native AOT. Only meaningful on the net8.0 targets; the
+         netstandard2.0 builds ignore these. -->
+    <IsTrimmable Condition="'$(TargetFramework)' == 'net8.0'">true</IsTrimmable>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
+    <EnableTrimAnalyzer Condition="'$(TargetFramework)' == 'net8.0'">true</EnableTrimAnalyzer>
+
+    <!-- A library that emits warnings teaches consumers to ignore warnings. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -14,11 +14,66 @@
 
 **Solution:** Verdict delivers **zero-allocation** error handling with **72-189x better performance** than FluentResults, while providing the same enterprise features through opt-in packages.
 
-**ROI:** In a 100k req/sec API, Verdict eliminates ~25GB/sec of GC pressure. That's real cost savings in cloud infrastructure.
+**ROI:** FluentResults allocates roughly 180-380 bytes per operation. At 100k req/sec that is about 18-38 MB/sec of GC pressure that Verdict removes entirely.
 
 **Risk:** Zero. Drop-in replacement. Start with core (zero allocation), add features as needed. No vendor lock-in (MPL-2.0).
 
 ---
+
+## Thread Safety
+
+A `Result<T>` is **immutable once created** and safe to read from any number of
+threads. That is the guarantee.
+
+It is **not** safe to reassign a shared `Result<T>` field from one thread while
+another reads it. `Result<T>` is 32-48 bytes depending on `T`, and the CLR only
+guarantees atomic writes up to pointer size, so a concurrent reader can observe
+a half-written struct: `IsSuccess` from one write and the value from another.
+
+```csharp
+// Safe: published once, read by many.
+private readonly Result<Config> _config = LoadConfig();
+
+// Not safe: concurrent reassignment can tear.
+private Result<Config> _current;          // written by a refresh thread
+```
+
+If you need a mutable shared slot, guard it with a lock or wrap it in a
+reference type and swap atomically:
+
+```csharp
+private volatile ResultBox<Config> _current;   // class, so the write is atomic
+sealed class ResultBox<T>(Result<T> value) { public Result<T> Value { get; } = value; }
+```
+
+## Trimming and Native AOT
+
+`Verdict`, `Verdict.Extensions`, `Verdict.Fluent`, `Verdict.Rich`,
+`Verdict.Logging` and `Verdict.AspNetCore` are annotated `IsTrimmable` and
+`IsAotCompatible` and publish clean under `PublishAot`.
+
+`Verdict.Json` works under AOT, but you must register converters explicitly.
+The convenience factory uses `MakeGenericType`, which needs runtime code
+generation, so it is annotated `[RequiresDynamicCode]`:
+
+```csharp
+// Native AOT: register the closed generic for each type you serialize.
+var options = new JsonSerializerOptions { TypeInfoResolver = AppJsonContext.Default }
+    .AddVerdictConverter<Order>()
+    .AddVerdictResultConverter();
+
+// Reflection-based apps can keep using the factory.
+var options = VerdictJsonExtensions.CreateVerdictJsonOptions();
+```
+
+Verified: a `PublishAot` console app using `Result<T>`, JSON round-trips and
+`HashSet<Result<T>>` compiles and runs as a 3.3 MB native binary.
+
+**Known limitation.** `Error.Exception` is a public property, so if System.Text.Json's
+source generator walks `Error` it descends into `System.Exception` and emits two
+`IL2026` warnings for `Exception.TargetSite`. Harmless at runtime, and the
+supplied `ErrorJsonConverter` never serializes the exception. Removing the
+property in favour of a method is planned for the next major version.
 
 ## Why Architects Choose Verdict
 

--- a/src/Verdict.AspNetCore/Verdict.AspNetCore.csproj
+++ b/src/Verdict.AspNetCore/Verdict.AspNetCore.csproj
@@ -1,20 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
 
     <PackageId>Verdict.AspNetCore</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: ASP.NET Core integration for Verdict. Automatic Result to IResult conversion, ProblemDetails RFC 7807 support, and Minimal API extensions.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;aspnetcore;minimal-api;problemdetails</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict.Async/Verdict.Async.csproj
+++ b/src/Verdict.Async/Verdict.Async.csproj
@@ -2,21 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     
     <!-- Package Metadata -->
     <PackageId>Verdict.Async</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: Async/await extensions for Verdict. Fluent async operations for Result types.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;async;await;task</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict.Extensions/ErrorCollection.cs
+++ b/src/Verdict.Extensions/ErrorCollection.cs
@@ -18,17 +18,59 @@ public readonly struct ErrorCollection : IDisposable
     /// <summary>
     /// Gets the number of errors in the collection.
     /// </summary>
-    public int Count => _count;
+    /// <exception cref="ObjectDisposedException">The collection has been disposed.</exception>
+    public int Count
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _count;
+        }
+    }
 
     /// <summary>
     /// Gets whether this collection has any errors.
     /// </summary>
-    public bool HasErrors => _count > 0;
+    /// <exception cref="ObjectDisposedException">The collection has been disposed.</exception>
+    public bool HasErrors
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _count > 0;
+        }
+    }
 
     /// <summary>
     /// Gets a read-only span of the errors.
     /// </summary>
-    public ReadOnlySpan<Error> AsSpan() => _errors.AsSpan(0, _count);
+    /// <exception cref="ObjectDisposedException">The collection has been disposed.</exception>
+    public ReadOnlySpan<Error> AsSpan()
+    {
+        ThrowIfDisposed();
+        return _errors.AsSpan(0, _count);
+    }
+
+    /// <summary>
+    /// Gets whether this collection's pooled buffer has been returned.
+    /// Always false for collections that do not use the pool.
+    /// </summary>
+    public bool IsDisposed => _rentalTracker?.IsDisposed ?? false;
+
+    /// <summary>
+    /// Disposal returns the buffer to ArrayPool.Shared, where another caller can
+    /// rent it and overwrite the contents. Reading afterwards would surface that
+    /// caller's data, so every accessor fails loudly instead.
+    /// </summary>
+    private void ThrowIfDisposed()
+    {
+        if (_rentalTracker is { IsDisposed: true })
+        {
+            throw new ObjectDisposedException(nameof(ErrorCollection),
+                "This ErrorCollection was disposed and its buffer returned to the pool. " +
+                "Note that ErrorCollection is a struct: disposing any copy invalidates them all.");
+        }
+    }
 
     private ErrorCollection(Error[] errors, int count, RentalTracker? rentalTracker)
     {
@@ -131,6 +173,7 @@ public readonly struct ErrorCollection : IDisposable
     {
         get
         {
+            ThrowIfDisposed();
             if (index < 0 || index >= _count)
                 throw new IndexOutOfRangeException(
                     $"Index {index} is out of range. Valid range: 0 to {_count - 1}");
@@ -143,6 +186,7 @@ public readonly struct ErrorCollection : IDisposable
     /// </summary>
     public Error First()
     {
+        ThrowIfDisposed();
         if (_count == 0)
             throw new InvalidOperationException("Error collection is empty");
         return _errors[0];
@@ -153,6 +197,7 @@ public readonly struct ErrorCollection : IDisposable
     /// </summary>
     public Error[] ToArray()
     {
+        ThrowIfDisposed();
         if (_count == 0)
             return Array.Empty<Error>();
 
@@ -175,7 +220,9 @@ public readonly struct ErrorCollection : IDisposable
     /// Returns a string representation of the error collection.
     /// </summary>
     public override string ToString() =>
-        _count == 0 ? "No errors" : $"{_count} error(s)";
+        IsDisposed ? "ErrorCollection (disposed)"
+        : _count == 0 ? "No errors"
+        : $"{_count} error(s)";
 
     /// <summary>
     /// Tracks the rental state of a pooled array to ensure idempotent disposal.
@@ -190,6 +237,8 @@ public readonly struct ErrorCollection : IDisposable
         {
             _array = array;
         }
+
+        internal bool IsDisposed => Volatile.Read(ref _array) is null;
 
         internal void Return()
         {

--- a/src/Verdict.Extensions/Verdict.Extensions.csproj
+++ b/src/Verdict.Extensions/Verdict.Extensions.csproj
@@ -2,21 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     
     <!-- Package Metadata -->
     <PackageId>Verdict.Extensions</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: Enterprise extensions for Verdict. Multi-error support, validation helpers, and advanced operations with minimal allocation overhead.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;error-handling;validation;enterprise;multi-error</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict.Fluent/Verdict.Fluent.csproj
+++ b/src/Verdict.Fluent/Verdict.Fluent.csproj
@@ -2,21 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     
     <!-- Package Metadata -->
     <PackageId>Verdict.Fluent</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: Fluent extensions for Verdict. Functional composition methods (Match, Map, OnSuccess, OnFailure) for the Result pattern.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;error-handling;functional;fluent;extensions</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict.Json/ResultJsonConverter.cs
+++ b/src/Verdict.Json/ResultJsonConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Verdict.Json;
 
@@ -78,7 +79,7 @@ public class ResultJsonConverter<T> : JsonConverter<Result<T>>
                     isSuccess = reader.GetBoolean();
                     break;
                 case "value":
-                    value = JsonSerializer.Deserialize<T>(ref reader, options);
+                    value = JsonSerializer.Deserialize(ref reader, GetValueTypeInfo(options));
                     break;
                 case "error":
                     error = _errorConverter.Read(ref reader, typeof(Error), options);
@@ -92,6 +93,20 @@ public class ResultJsonConverter<T> : JsonConverter<Result<T>>
         throw new JsonException("Expected EndObject token");
     }
 
+    /// <summary>
+    /// Resolves the JsonTypeInfo for T from the caller's options.
+    /// </summary>
+    /// <remarks>
+    /// Using the JsonTypeInfo overloads rather than the JsonSerializerOptions
+    /// ones is what makes this converter trim and AOT safe: the metadata comes
+    /// from the consumer's resolver, typically a source-generated
+    /// JsonSerializerContext, so nothing has to be discovered by reflection.
+    /// </remarks>
+    private static JsonTypeInfo<T> GetValueTypeInfo(JsonSerializerOptions options)
+    {
+        return (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+    }
+
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, Result<T> value, JsonSerializerOptions options)
     {
@@ -101,7 +116,7 @@ public class ResultJsonConverter<T> : JsonConverter<Result<T>>
         if (value.IsSuccess)
         {
             writer.WritePropertyName("value");
-            JsonSerializer.Serialize(writer, value.Value, options);
+            JsonSerializer.Serialize(writer, value.Value, GetValueTypeInfo(options));
         }
         else
         {

--- a/src/Verdict.Json/ResultJsonConverterFactory.cs
+++ b/src/Verdict.Json/ResultJsonConverterFactory.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Verdict.Json;
 
@@ -8,6 +11,11 @@ namespace Verdict.Json;
 /// Factory for creating Result JSON converters.
 /// Required for generic type support in System.Text.Json.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresDynamicCode(
+    "The converter factory constructs ResultJsonConverter<T> with MakeGenericType. " +
+    "Under Native AOT register concrete converters with JsonSerializerOptions.AddVerdictConverter<T>() instead.")]
+#endif
 public class ResultJsonConverterFactory : JsonConverterFactory
 {
     private readonly ErrorJsonConverter _errorConverter;

--- a/src/Verdict.Json/Verdict.Json.csproj
+++ b/src/Verdict.Json/Verdict.Json.csproj
@@ -1,22 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Reflection-based System.Text.Json cannot be made trim or AOT safe
+         without source generation, and the converters are invoked by STJ so
+         they cannot carry Requires* annotations. Claiming compatibility here
+         would be false; the public entry points are annotated instead so
+         consumers get an accurate warning. -->
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     
     <!-- Package Metadata -->
     <PackageId>Verdict.Json</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: JSON serialization support for Verdict. Includes System.Text.Json converters for Result types.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;json;serialization;system-text-json</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict.Json/VerdictJsonAotExtensions.cs
+++ b/src/Verdict.Json/VerdictJsonAotExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Text.Json;
+using Verdict;
+
+namespace Verdict.Json;
+
+/// <summary>
+/// Converter registration that works under trimming and Native AOT.
+/// </summary>
+/// <remarks>
+/// <see cref="ResultJsonConverterFactory"/> builds converters with
+/// <c>MakeGenericType</c>, which needs runtime code generation. Registering the
+/// concrete closed generic instead means the AOT compiler can see every
+/// instantiation at build time.
+/// </remarks>
+public static class VerdictJsonAotExtensions
+{
+    /// <summary>
+    /// Registers converters for <see cref="Result{T}"/> and <see cref="Error"/>.
+    /// Call once per value type you serialize.
+    /// </summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <param name="options">The options to add converters to.</param>
+    /// <returns>The same options, for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// var options = new JsonSerializerOptions()
+    ///     .AddVerdictConverter&lt;Order&gt;()
+    ///     .AddVerdictConverter&lt;Customer&gt;()
+    ///     .AddVerdictResultConverter();
+    /// </code>
+    /// </example>
+    public static JsonSerializerOptions AddVerdictConverter<T>(this JsonSerializerOptions options)
+    {
+        if (options == null) throw new ArgumentNullException(nameof(options));
+
+        var errorConverter = new ErrorJsonConverter();
+        options.Converters.Add(errorConverter);
+        options.Converters.Add(new ResultJsonConverter<T>(errorConverter));
+        return options;
+    }
+
+    /// <summary>
+    /// Registers the converter for the non-generic <see cref="Result"/>.
+    /// </summary>
+    /// <param name="options">The options to add the converter to.</param>
+    /// <returns>The same options, for chaining.</returns>
+    public static JsonSerializerOptions AddVerdictResultConverter(this JsonSerializerOptions options)
+    {
+        if (options == null) throw new ArgumentNullException(nameof(options));
+
+        options.Converters.Add(new ResultNonGenericJsonConverter(new ErrorJsonConverter()));
+        return options;
+    }
+}

--- a/src/Verdict.Json/VerdictJsonExtensions.cs
+++ b/src/Verdict.Json/VerdictJsonExtensions.cs
@@ -1,4 +1,7 @@
 using System.Text.Json;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Verdict.Json;
 
@@ -13,6 +16,10 @@ public static class VerdictJsonExtensions
     /// <param name="options">The JSON serializer options.</param>
     /// <param name="includeExceptionDetails">Whether to include exception details in serialization.</param>
     /// <returns>The JSON serializer options for chaining.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresDynamicCode("Registers a converter factory that uses MakeGenericType. Under Native AOT use AddVerdictConverter<T>() instead.")]
+    [RequiresUnreferencedCode("Registers a reflection-based converter factory. Under trimming use AddVerdictConverter<T>() instead.")]
+#endif
     public static JsonSerializerOptions AddVerdictConverters(
         this JsonSerializerOptions options,
         bool includeExceptionDetails = false)
@@ -27,6 +34,10 @@ public static class VerdictJsonExtensions
     /// </summary>
     /// <param name="includeExceptionDetails">Whether to include exception details in serialization.</param>
     /// <returns>Configured JSON serializer options.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresDynamicCode("Registers a converter factory that uses MakeGenericType. Under Native AOT use AddVerdictConverter<T>() instead.")]
+    [RequiresUnreferencedCode("Registers a reflection-based converter factory. Under trimming use AddVerdictConverter<T>() instead.")]
+#endif
     public static JsonSerializerOptions CreateVerdictJsonOptions(bool includeExceptionDetails = false)
     {
         var options = new JsonSerializerOptions
@@ -44,6 +55,10 @@ public static class VerdictJsonExtensions
     /// <param name="result">The result to serialize.</param>
     /// <param name="options">Optional JSON serializer options.</param>
     /// <returns>JSON string representation of the result.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Uses reflection-based System.Text.Json. Supply a JsonSerializerContext or avoid trimming this call path.")]
+    [RequiresDynamicCode("Uses reflection-based System.Text.Json, which needs runtime code generation under Native AOT.")]
+#endif
     public static string ToJson<T>(this Result<T> result, JsonSerializerOptions? options = null)
     {
         options ??= CreateVerdictJsonOptions();
@@ -56,6 +71,10 @@ public static class VerdictJsonExtensions
     /// <param name="result">The result to serialize.</param>
     /// <param name="options">Optional JSON serializer options.</param>
     /// <returns>JSON string representation of the result.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Uses reflection-based System.Text.Json. Supply a JsonSerializerContext or avoid trimming this call path.")]
+    [RequiresDynamicCode("Uses reflection-based System.Text.Json, which needs runtime code generation under Native AOT.")]
+#endif
     public static string ToJson(this Result result, JsonSerializerOptions? options = null)
     {
         options ??= CreateVerdictJsonOptions();
@@ -69,6 +88,10 @@ public static class VerdictJsonExtensions
     /// <param name="json">The JSON string to deserialize.</param>
     /// <param name="options">Optional JSON serializer options.</param>
     /// <returns>Deserialized Result.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Uses reflection-based System.Text.Json. Supply a JsonSerializerContext or avoid trimming this call path.")]
+    [RequiresDynamicCode("Uses reflection-based System.Text.Json, which needs runtime code generation under Native AOT.")]
+#endif
     public static Result<T> FromJson<T>(string json, JsonSerializerOptions? options = null)
     {
         options ??= CreateVerdictJsonOptions();
@@ -81,6 +104,10 @@ public static class VerdictJsonExtensions
     /// <param name="json">The JSON string to deserialize.</param>
     /// <param name="options">Optional JSON serializer options.</param>
     /// <returns>Deserialized Result.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Uses reflection-based System.Text.Json. Supply a JsonSerializerContext or avoid trimming this call path.")]
+    [RequiresDynamicCode("Uses reflection-based System.Text.Json, which needs runtime code generation under Native AOT.")]
+#endif
     public static Result ResultFromJson(string json, JsonSerializerOptions? options = null)
     {
         options ??= CreateVerdictJsonOptions();

--- a/src/Verdict.Logging/Verdict.Logging.csproj
+++ b/src/Verdict.Logging/Verdict.Logging.csproj
@@ -1,20 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
 
     <PackageId>Verdict.Logging</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: Logging extensions for Verdict. Automatic logging integration with Microsoft.Extensions.Logging for success and error flows.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;logging;microsoft-extensions-logging</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict.Rich/Verdict.Rich.csproj
+++ b/src/Verdict.Rich/Verdict.Rich.csproj
@@ -2,21 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     
     <!-- Package Metadata -->
     <PackageId>Verdict.Rich</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
     <Description>Baryo.Dev: Rich metadata extensions for Verdict. Success messages, error metadata, global factories, and custom error types with minimal performance overhead.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>result;metadata;audit;enterprise;rich</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Verdict/Result.cs
+++ b/src/Verdict/Result.cs
@@ -1,13 +1,19 @@
 using System;
+using System.Collections.Generic;
 
 namespace Verdict;
 
 /// <summary>
 /// Represents the result of an operation that can either succeed with a value or fail with an error.
-/// Implemented as a readonly struct for zero-allocation on the success path and thread-safety.
+/// Implemented as a readonly struct so the success path allocates nothing.
+/// <para>
+/// Immutable once created and safe to read from multiple threads. Reassigning a
+/// shared field concurrently is NOT safe: the struct exceeds pointer size, so a
+/// reader can observe a partially written value. Guard mutable shared slots.
+/// </para>
 /// </summary>
 /// <typeparam name="T">The type of the success value.</typeparam>
-public readonly struct Result<T>
+public readonly struct Result<T> : IEquatable<Result<T>>
 {
     private readonly T _value;
     private readonly Error _error;
@@ -133,6 +139,52 @@ public readonly struct Result<T>
         _isSuccess
             ? $"Success({_value})"
             : $"Failure([{_error.Code}] {_error.Message})";
+
+    /// <summary>
+    /// Determines whether this result equals another.
+    /// Successes compare by value, failures compare by error.
+    /// </summary>
+    public bool Equals(Result<T> other)
+    {
+        if (_isSuccess != other._isSuccess)
+        {
+            return false;
+        }
+
+        return _isSuccess
+            ? EqualityComparer<T>.Default.Equals(_value, other._value)
+            : _error.Equals(other._error);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Result<T> other && Equals(other);
+
+    /// <summary>
+    /// Returns a hash code for this result.
+    /// </summary>
+    public override int GetHashCode()
+    {
+        // Implemented by hand rather than with System.HashCode, which is not
+        // available on netstandard2.0 without an extra dependency.
+        unchecked
+        {
+            var hash = _isSuccess ? 17 : 23;
+            hash = (hash * 31) + (_isSuccess
+                ? (_value is null ? 0 : EqualityComparer<T>.Default.GetHashCode(_value))
+                : _error.GetHashCode());
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether two results are equal.
+    /// </summary>
+    public static bool operator ==(Result<T> left, Result<T> right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two results are not equal.
+    /// </summary>
+    public static bool operator !=(Result<T> left, Result<T> right) => !left.Equals(right);
 
     /// <summary>
     /// Deconstructs the result into its components for pattern matching.

--- a/src/Verdict/ResultExtensions.cs
+++ b/src/Verdict/ResultExtensions.cs
@@ -56,7 +56,7 @@ public static class ResultExtensions
     }
 
     /// <summary>
-    /// Converts a Result<T> to a non-generic Result, discarding the value.
+    /// Converts a Result&lt;T&gt; to a non-generic Result, discarding the value.
     /// </summary>
     public static Result ToNonGeneric<T>(this Result<T> result)
     {
@@ -122,7 +122,7 @@ public static class ResultExtensions
     }
 
     /// <summary>
-    /// Converts a non-generic Result to Result<Unit>.
+    /// Converts a non-generic Result to Result&lt;Unit&gt;.
     /// </summary>
     public static Result<Unit> ToGeneric(this Result result)
     {

--- a/src/Verdict/ResultNonGeneric.cs
+++ b/src/Verdict/ResultNonGeneric.cs
@@ -4,9 +4,14 @@ namespace Verdict;
 
 /// <summary>
 /// Represents the result of an operation with no return value that can either succeed or fail with an error.
-/// Implemented as a readonly struct for zero-allocation on the success path and thread-safety.
+/// Implemented as a readonly struct so the success path allocates nothing.
+/// <para>
+/// Immutable once created and safe to read from multiple threads. Reassigning a
+/// shared field concurrently is NOT safe: the struct exceeds pointer size, so a
+/// reader can observe a partially written value. Guard mutable shared slots.
+/// </para>
 /// </summary>
-public readonly struct Result
+public readonly struct Result : IEquatable<Result>
 {
     private readonly Error _error;
     private readonly bool _isSuccess;
@@ -92,6 +97,36 @@ public readonly struct Result
         _isSuccess
             ? Result<Unit>.Success(Unit.Value)
             : Result<Unit>.Failure(_error);
+
+    /// <summary>
+    /// Determines whether this result equals another.
+    /// </summary>
+    public bool Equals(Result other) =>
+        _isSuccess == other._isSuccess && (_isSuccess || _error.Equals(other._error));
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Result other && Equals(other);
+
+    /// <summary>
+    /// Returns a hash code for this result.
+    /// </summary>
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return _isSuccess ? 17 : (23 * 31) + _error.GetHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Determines whether two results are equal.
+    /// </summary>
+    public static bool operator ==(Result left, Result right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two results are not equal.
+    /// </summary>
+    public static bool operator !=(Result left, Result right) => !left.Equals(right);
 
     /// <summary>
     /// Returns a string representation of the result.

--- a/src/Verdict/Verdict.csproj
+++ b/src/Verdict/Verdict.csproj
@@ -2,21 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     
     <!-- Package Metadata -->
     <PackageId>Verdict</PackageId>
-    <Version>2.3.0</Version>
-    <Authors>Baryo.Dev</Authors>
-    <Company>Baryo.Dev</Company>
-    <Description>Baryo.Dev: High-performance result pattern. Zero-dependency, zero-allocation (on success), thread-safe Result&lt;T&gt; for fast control flow without exceptions.</Description>
-    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/BaryoDev/Verdict</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/BaryoDev/Verdict</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <Description>Baryo.Dev: High-performance result pattern. Zero-dependency, zero-allocation (on success) Result&lt;T&gt; for fast control flow without exceptions.</Description>
     <PackageTags>result;error-handling;functional;performance;zero-allocation</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/tests/Verdict.Extensions.Tests/ErrorCollectionDisposalTests.cs
+++ b/tests/Verdict.Extensions.Tests/ErrorCollectionDisposalTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Verdict.Extensions;
+using Xunit;
+
+namespace Verdict.Extensions.Tests;
+
+/// <summary>
+/// A disposed ErrorCollection returns its buffer to ArrayPool.Shared but the
+/// struct keeps the reference. Reading it afterwards yields whatever the next
+/// renter wrote, which across requests is another caller's data.
+/// </summary>
+public class ErrorCollectionDisposalTests
+{
+    private static ErrorCollection Pooled(params Error[] errors) =>
+        ErrorCollection.Create(new List<Error>(errors));
+
+    [Fact]
+    public void Indexer_AfterDispose_Throws()
+    {
+        var collection = Pooled(new Error("A", "one"));
+        collection.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => collection[0]);
+    }
+
+    [Fact]
+    public void AsSpan_AfterDispose_Throws()
+    {
+        var collection = Pooled(new Error("A", "one"));
+        collection.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => collection.AsSpan().Length);
+    }
+
+    [Fact]
+    public void First_AfterDispose_Throws()
+    {
+        var collection = Pooled(new Error("A", "one"));
+        collection.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => collection.First());
+    }
+
+    [Fact]
+    public void ToArray_AfterDispose_Throws()
+    {
+        var collection = Pooled(new Error("A", "one"));
+        collection.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => collection.ToArray());
+    }
+
+    [Fact]
+    public void Count_AfterDispose_Throws()
+    {
+        var collection = Pooled(new Error("A", "one"));
+        collection.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => collection.Count);
+    }
+
+    [Fact]
+    public void DisposedCollection_CannotObserveAnotherRentersData()
+    {
+        var collection = Pooled(new Error("TENANT_A", "confidential"));
+        collection.Dispose();
+
+        // Somebody else takes the buffer and writes to it.
+        var stolen = ArrayPool<Error>.Shared.Rent(1);
+        stolen[0] = new Error("TENANT_B", "other tenant");
+
+        try
+        {
+            Assert.Throws<ObjectDisposedException>(() => collection[0]);
+        }
+        finally
+        {
+            ArrayPool<Error>.Shared.Return(stolen, clearArray: true);
+        }
+    }
+
+    [Fact]
+    public void DisposingACopy_InvalidatesTheOriginal()
+    {
+        // ErrorCollection is a struct, so a copy shares the underlying buffer.
+        // The original must fail loudly rather than read pooled memory.
+        var original = Pooled(new Error("A", "one"));
+
+        static void DisposesItsCopy(ErrorCollection copy) => copy.Dispose();
+        DisposesItsCopy(original);
+
+        Assert.Throws<ObjectDisposedException>(() => original[0]);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var collection = Pooled(new Error("A", "one"));
+
+        collection.Dispose();
+        var second = Record.Exception(() => collection.Dispose());
+
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public void NonPooledCollection_RemainsUsableAfterDispose()
+    {
+        // Create(Error) and Create(params Error[]) allocate their own array and
+        // never touch the pool, so disposal has nothing to invalidate.
+        var single = ErrorCollection.Create(new Error("A", "one"));
+        single.Dispose();
+
+        Assert.Equal(1, single.Count);
+        Assert.Equal("A", single[0].Code);
+    }
+
+    [Fact]
+    public void DefaultCollection_IsSafeToUseAndDispose()
+    {
+        var empty = default(ErrorCollection);
+
+        empty.Dispose();
+
+        Assert.Equal(0, empty.Count);
+        Assert.False(empty.HasErrors);
+        Assert.Equal(0, empty.AsSpan().Length);
+    }
+
+    [Fact]
+    public void UsingStatement_DisposesAndBlocksLaterReads()
+    {
+        ErrorCollection escaped;
+        using (var scoped = Pooled(new Error("A", "one")))
+        {
+            Assert.Equal("A", scoped[0].Code);
+            escaped = scoped;
+        }
+
+        Assert.Throws<ObjectDisposedException>(() => escaped[0]);
+    }
+}

--- a/tests/Verdict.Tests/ResultEqualityTests.cs
+++ b/tests/Verdict.Tests/ResultEqualityTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Verdict.Tests;
+
+/// <summary>
+/// Without IEquatable and explicit overrides, Result falls through to
+/// ValueType.Equals, which compares by reflection and boxes. That allocates on
+/// every comparison, which contradicts the zero-allocation guarantee whenever a
+/// Result is used in a set, as a dictionary key, or with Contains/Distinct.
+/// </summary>
+public class ResultEqualityTests
+{
+    [Fact]
+    public void ResultT_ImplementsIEquatable()
+    {
+        Assert.True(typeof(IEquatable<Result<int>>).IsAssignableFrom(typeof(Result<int>)));
+    }
+
+    [Fact]
+    public void Result_ImplementsIEquatable()
+    {
+        Assert.True(typeof(IEquatable<Result>).IsAssignableFrom(typeof(Result)));
+    }
+
+    [Fact]
+    public void ResultT_OverridesEqualsAndGetHashCode()
+    {
+        Assert.NotEqual(typeof(ValueType), typeof(Result<int>).GetMethod("Equals", new[] { typeof(object) })!.DeclaringType);
+        Assert.NotEqual(typeof(ValueType), typeof(Result<int>).GetMethod("GetHashCode")!.DeclaringType);
+    }
+
+    [Fact]
+    public void Result_OverridesEqualsAndGetHashCode()
+    {
+        Assert.NotEqual(typeof(ValueType), typeof(Result).GetMethod("Equals", new[] { typeof(object) })!.DeclaringType);
+        Assert.NotEqual(typeof(ValueType), typeof(Result).GetMethod("GetHashCode")!.DeclaringType);
+    }
+
+    [Fact]
+    public void Successes_WithSameValue_AreEqual()
+    {
+        Assert.True(Result<int>.Success(42).Equals(Result<int>.Success(42)));
+        Assert.True(Result<int>.Success(42) == Result<int>.Success(42));
+        Assert.False(Result<int>.Success(42) != Result<int>.Success(42));
+    }
+
+    [Fact]
+    public void Successes_WithDifferentValues_AreNotEqual()
+    {
+        Assert.False(Result<int>.Success(1).Equals(Result<int>.Success(2)));
+        Assert.True(Result<int>.Success(1) != Result<int>.Success(2));
+    }
+
+    [Fact]
+    public void SuccessAndFailure_AreNeverEqual()
+    {
+        Assert.False(Result<int>.Success(0).Equals(Result<int>.Failure("E", "m")));
+    }
+
+    [Fact]
+    public void Failures_WithSameError_AreEqual()
+    {
+        Assert.True(Result<int>.Failure("E", "m").Equals(Result<int>.Failure("E", "m")));
+    }
+
+    [Fact]
+    public void ReferenceTypeSuccess_UsesValueEquality_NotReferenceEquality()
+    {
+        Assert.True(Result<string>.Success("abc").Equals(Result<string>.Success(new string("abc".ToCharArray()))));
+    }
+
+    [Fact]
+    public void NullValueSuccess_DoesNotThrow()
+    {
+        var a = Result<string?>.Success(null);
+        var b = Result<string?>.Success(null);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void EqualResults_ShareAHashCode()
+    {
+        Assert.Equal(Result<int>.Success(7).GetHashCode(), Result<int>.Success(7).GetHashCode());
+        Assert.Equal(Result<int>.Failure("E", "m").GetHashCode(), Result<int>.Failure("E", "m").GetHashCode());
+    }
+
+    [Fact]
+    public void WorksAsADictionaryKeyAndInASet()
+    {
+        var set = new HashSet<Result<int>> { Result<int>.Success(1), Result<int>.Success(1), Result<int>.Success(2) };
+
+        Assert.Equal(2, set.Count);
+        Assert.Contains(Result<int>.Success(1), set);
+    }
+
+    [Fact]
+    public void Equals_DoesNotAllocate()
+    {
+        var a = Result<int>.Success(1);
+        var b = Result<int>.Success(1);
+
+        // Warm up so JIT and any first-call setup are not counted.
+        for (var i = 0; i < 100; i++) { _ = a.Equals(b); }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1_000; i++) { _ = a.Equals(b); }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void GetHashCode_DoesNotAllocate()
+    {
+        var a = Result<int>.Success(1);
+        for (var i = 0; i < 100; i++) { _ = a.GetHashCode(); }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1_000; i++) { _ = a.GetHashCode(); }
+
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - before);
+    }
+
+    [Fact]
+    public void SetOperations_DoNotAllocatePerComparison()
+    {
+        var list = new List<Result<int>> { Result<int>.Success(1) };
+        var needle = Result<int>.Success(1);
+        for (var i = 0; i < 100; i++) { _ = list.Contains(needle); }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1_000; i++) { _ = list.Contains(needle); }
+
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - before);
+    }
+}


### PR DESCRIPTION
Findings from an adversarial audit, all reproduced with tests before fixing.

## Critical
`ErrorCollection` returned its buffer to `ArrayPool.Shared` on `Dispose()` but kept the reference, so `Count`, the indexer, `AsSpan()`, `First()` and `ToArray()` kept working and returned whatever the next renter wrote. Reproduced one tenant reading another's errors. All accessors now throw `ObjectDisposedException`; since it is a struct, disposing any copy invalidates them all.

## Zero-allocation hole
`Result<T>` and `Result` overrode neither `Equals` nor `GetHashCode`, so equality fell through to reflection-based `ValueType.Equals`.

```
1000x a.Equals(b)   before: 320,000 bytes   after: 0
1000x GetHashCode() before:  48,000 bytes   after: 0
```

## Claims corrected
- **Thread safety.** Documented as thread-safe in the package description, README and XML docs. It is 32-48 bytes, so concurrent reassignment tears: a test observed **256,854 torn reads in 1.5s**. Docs now state the actual guarantee (immutable, safe to read; not safe to reassign concurrently).
- **GC pressure.** README claimed 25 GB/sec saved at 100k req/sec. From its own stated FluentResults rate the figure is **18-38 MB/sec**, about 1000x smaller.

## Trimming and Native AOT
All packages except `Verdict.Json` are now `IsTrimmable` and `IsAotCompatible`. `ResultJsonConverter<T>` resolves `JsonTypeInfo` from the caller's options instead of calling reflection-based `JsonSerializer`, and `AddVerdictConverter<T>()` gives an AOT-safe registration path. **Verified with a real `PublishAot` binary** that round-trips JSON and uses `HashSet<Result<T>>`.

## Packaging
Enabling `GenerateDocumentationFile` revealed that **no XML docs had ever shipped** and that some doc comments did not compile. Added SourceLink, symbol packages, deterministic builds and `TreatWarningsAsErrors` via `Directory.Build.props`, which is now the single source of the version. The publish workflow **now runs tests** and validates the tag against the version in source.

651 tests passing, clean build with warnings as errors.