### PR TITLE
ci: publish to NuGet with trusted publishing instead of a stored API key

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # NuGet trusted publishing
+      # Lets the runner mint the OIDC token nuget.org exchanges for a
+      # short-lived API key. No long-lived secret is involved.
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -68,13 +70,19 @@ jobs:
           name: nupkgs
           path: ./nupkgs/*
 
+      # Requested here rather than earlier because the key expires after an
+      # hour and each OIDC token buys exactly one key.
+      - name: Exchange OIDC token for a short-lived NuGet key
+        if: ${{ !inputs.dry_run }}
+        id: nuget_login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER || 'arnelirobles' }}
+
       - name: Publish
         if: ${{ !inputs.dry_run }}
         run: |
-          if [ -z "${{ secrets.NUGET_API_KEY }}" ]; then
-            echo "::error::NUGET_API_KEY secret is not set." && exit 1
-          fi
           dotnet nuget push ./nupkgs/*.nupkg \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -72,12 +72,20 @@ jobs:
 
       # Requested here rather than earlier because the key expires after an
       # hour and each OIDC token buys exactly one key.
+      # Runs on dry runs too, so a dry run actually verifies the trusted
+      # publishing policy. Obtaining a key publishes nothing.
       - name: Exchange OIDC token for a short-lived NuGet key
-        if: ${{ !inputs.dry_run }}
         id: nuget_login
         uses: NuGet/login@v1
         with:
           user: ${{ vars.NUGET_USER || 'arnelirobles' }}
+
+      - name: Confirm the key was issued
+        run: |
+          if [ -z "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" ]; then
+            echo "::error::No API key returned. Check the trusted publishing policy on nuget.org." && exit 1
+          fi
+          echo "Trusted publishing OK: short-lived key issued."
 
       - name: Publish
         if: ${{ !inputs.dry_run }}

--- a/README.md
+++ b/README.md
@@ -460,6 +460,38 @@ Optional functional extensions:
 ### Benchmarks (`Verdict.Benchmarks`)
 Performance validation using BenchmarkDotNet.
 
+## Releasing
+
+Publishing uses **NuGet Trusted Publishing**. No API key is stored in this
+repository; the workflow exchanges a short-lived GitHub OIDC token for a NuGet
+key that expires after an hour.
+
+The version comes from `<VersionPrefix>` in `Directory.Build.props`, so the
+released version is always recorded in git.
+
+```bash
+# bump VersionPrefix, update CHANGELOG, then:
+git tag v2.6.0 && git push origin v2.6.0
+```
+
+The workflow verifies manifests, runs the tests, builds, checks the tag matches
+the version in source, then publishes. Run it manually from the Actions tab with
+**dry run** checked to build and pack without publishing.
+
+### The trusted publishing policy
+
+Configured once on nuget.org under **Account → Trusted Publishing**. It is
+per-owner, so one policy covers every package:
+
+| Field | Value |
+| --- | --- |
+| Repository Owner | `BaryoDev` |
+| Repository | `Verdict` |
+| Workflow File | `publish-nuget.yml` (filename only, no path) |
+| Environment | leave empty |
+
+Renaming the workflow file breaks publishing until the policy is updated.
+
 ## Documentation
 
 ### For Architects & Decision Makers


### PR DESCRIPTION
Replaces the long-lived `NUGET_API_KEY` secret with OIDC. The workflow exchanges a short-lived GitHub token for a NuGet key valid for one hour, requested immediately before the push.

## Requires one setup step before the next release

On nuget.org, **Account → Trusted Publishing**, add a policy:

| Field | Value |
|---|---|
| Repository Owner | `BaryoDev` |
| Repository | `Verdict` |
| Workflow File | `publish-nuget.yml` (filename only, no `.github/workflows/` path) |
| Environment | leave empty |

Unlike npm, **the policy is per-owner rather than per-package**, so this single entry covers all eight packages.

## Notes

- The key is requested in its own step just before pushing, since it expires after an hour and each OIDC token buys exactly one key.
- The nuget.org username is `arnelirobles`, read from the package owner metadata. It is a repository variable `NUGET_USER` with that literal as the fallback, so it works without extra configuration.
- Renaming `publish-nuget.yml` will break publishing until the policy is updated. Documented in the README.
- **After the first successful publish, delete the `NUGET_API_KEY` secret.** It is no longer referenced anywhere.