### PR TITLE
feat(aspnetcore): scope ProblemDetails configuration to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`AddVerdictProblemDetails` registered nothing in the container.** It took an
+  `IServiceCollection`, assigned a process-wide static, and returned the
+  collection untouched. Two applications hosted in one process therefore shared
+  a single configuration and the last registration won. Options and services are
+  now registered properly and scoped to the container.
+
+### Added
+
+- `IVerdictProblemDetailsFactory` and `IErrorStatusCodeMapper`, both registered
+  by `AddVerdictProblemDetails`, so ProblemDetails generation and status code
+  mapping read the options of the container they are resolved from.
+- `VerdictProblemDetailsOptions.StatusCodeMappings` for per-container error code
+  to status code mappings, checked before the shared defaults. Prefer this to
+  the process-wide `ErrorStatusCodeMapper.RegisterMapping`.
+- `ProblemDetailsFactory.ResetDefaultOptions()` so tests can restore the
+  process-wide default instead of leaking configuration into later tests.
+
+### Notes
+
+The static path is unchanged and still supported. `ToActionResult` and
+`ToHttpResult` are extension methods with no access to DI, so they continue to
+read the process-wide defaults, which `AddVerdictProblemDetails` still assigns.
+For a single application both paths agree.
+
 ## [2.6.0] - 2026-08-07
 
 ### Added

--- a/src/Verdict.AspNetCore/IErrorStatusCodeMapper.cs
+++ b/src/Verdict.AspNetCore/IErrorStatusCodeMapper.cs
@@ -1,0 +1,19 @@
+using Verdict;
+
+namespace Verdict.AspNetCore;
+
+/// <summary>
+/// Maps an <see cref="Error"/> to an HTTP status code.
+/// </summary>
+/// <remarks>
+/// Resolve this from DI so mappings belong to a container rather than to the
+/// process. The static <see cref="ErrorStatusCodeMapper"/> remains available and
+/// is what the parameterless extension methods use.
+/// </remarks>
+public interface IErrorStatusCodeMapper
+{
+    /// <summary>
+    /// Returns the status code for an error, falling back to 400.
+    /// </summary>
+    int GetStatusCode(Error error);
+}

--- a/src/Verdict.AspNetCore/IVerdictProblemDetailsFactory.cs
+++ b/src/Verdict.AspNetCore/IVerdictProblemDetailsFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using Verdict;
+
+namespace Verdict.AspNetCore;
+
+/// <summary>
+/// Creates RFC 7807 ProblemDetails from an <see cref="Error"/>.
+/// </summary>
+/// <remarks>
+/// Resolve this from DI to use the options registered in that container. The
+/// static <see cref="ProblemDetailsFactory"/> remains available.
+/// </remarks>
+public interface IVerdictProblemDetailsFactory
+{
+    /// <summary>
+    /// Creates ProblemDetails for an error and status code.
+    /// </summary>
+    ProblemDetails CreateFromError(Error error, int statusCode = 400);
+}

--- a/src/Verdict.AspNetCore/ProblemDetailsFactory.cs
+++ b/src/Verdict.AspNetCore/ProblemDetailsFactory.cs
@@ -24,6 +24,21 @@ public static class ProblemDetailsFactory
     }
 
     /// <summary>
+    /// Restores the process-wide defaults.
+    /// </summary>
+    /// <remarks>
+    /// The default options are static, so a test that configures them affects
+    /// every test that runs afterwards in the same process. Call this in
+    /// teardown, or prefer the DI-scoped
+    /// <see cref="IVerdictProblemDetailsFactory"/>, which reads options from a
+    /// container instead.
+    /// </remarks>
+    public static void ResetDefaultOptions()
+    {
+        Interlocked.Exchange(ref _defaultOptions, new VerdictProblemDetailsOptions());
+    }
+
+    /// <summary>
     /// Creates ProblemDetails from an Error.
     /// Maps Error.Code to ProblemDetails.Type
     /// Maps Error.Message to ProblemDetails.Detail

--- a/src/Verdict.AspNetCore/ScopedServices.cs
+++ b/src/Verdict.AspNetCore/ScopedServices.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Verdict;
+
+namespace Verdict.AspNetCore;
+
+/// <summary>
+/// Status code mapper backed by the options registered in a container.
+/// </summary>
+internal sealed class OptionsErrorStatusCodeMapper : IErrorStatusCodeMapper
+{
+    private readonly IReadOnlyDictionary<string, int> _mappings;
+
+    public OptionsErrorStatusCodeMapper(IOptions<VerdictProblemDetailsOptions> options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        _mappings = options.Value.StatusCodeMappings;
+    }
+
+    public int GetStatusCode(Error error)
+    {
+        // Container-scoped mappings win, then the shared defaults.
+        if (!string.IsNullOrEmpty(error.Code) && _mappings.TryGetValue(error.Code, out var code))
+        {
+            return code;
+        }
+
+        return ErrorStatusCodeMapper.GetStatusCode(error);
+    }
+}
+
+/// <summary>
+/// ProblemDetails factory backed by the options registered in a container.
+/// </summary>
+internal sealed class OptionsProblemDetailsFactory : IVerdictProblemDetailsFactory
+{
+    private readonly VerdictProblemDetailsOptions _options;
+
+    public OptionsProblemDetailsFactory(IOptions<VerdictProblemDetailsOptions> options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        _options = options.Value;
+    }
+
+    public ProblemDetails CreateFromError(Error error, int statusCode = 400) =>
+        ProblemDetailsFactory.CreateFromError(error, statusCode, _options);
+}

--- a/src/Verdict.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Verdict.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Verdict.AspNetCore;
 
@@ -19,10 +20,9 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         Action<VerdictProblemDetailsOptions>? configure = null)
     {
-        var options = new VerdictProblemDetailsOptions();
-        configure?.Invoke(options);
-        ProblemDetailsFactory.SetDefaultOptions(options);
-        return services;
+        if (services is null) throw new ArgumentNullException(nameof(services));
+
+        return services.AddVerdictCore(new VerdictProblemDetailsOptions(), configure);
     }
 
     /// <summary>
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
         IHostEnvironment environment,
         Action<VerdictProblemDetailsOptions>? configure = null)
     {
+        if (services is null) throw new ArgumentNullException(nameof(services));
         if (environment == null) throw new ArgumentNullException(nameof(environment));
 
         var options = new VerdictProblemDetailsOptions
@@ -48,8 +49,37 @@ public static class ServiceCollectionExtensions
             IncludeErrorCode = true
         };
 
+        return services.AddVerdictCore(options, configure);
+    }
+
+    /// <summary>
+    /// Registers the options and the services that read them.
+    /// </summary>
+    /// <remarks>
+    /// Previously this method registered nothing and only assigned a static, so
+    /// two hosts in one process shared a single configuration and the last
+    /// registration won. Options and services are now container-scoped. The
+    /// static default is still assigned so the parameterless extension methods,
+    /// which have no access to DI, keep behaving as configured.
+    /// </remarks>
+    private static IServiceCollection AddVerdictCore(
+        this IServiceCollection services,
+        VerdictProblemDetailsOptions options,
+        Action<VerdictProblemDetailsOptions>? configure)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+
         configure?.Invoke(options);
+
+        services.AddSingleton<IOptions<VerdictProblemDetailsOptions>>(
+            new OptionsWrapper<VerdictProblemDetailsOptions>(options));
+        services.AddSingleton<IErrorStatusCodeMapper, OptionsErrorStatusCodeMapper>();
+        services.AddSingleton<IVerdictProblemDetailsFactory, OptionsProblemDetailsFactory>();
+
+        // Kept so the parameterless ToActionResult/ToHttpResult overloads, which
+        // cannot reach the container, still honour this configuration.
         ProblemDetailsFactory.SetDefaultOptions(options);
+
         return services;
     }
 }

--- a/src/Verdict.AspNetCore/VerdictProblemDetailsOptions.cs
+++ b/src/Verdict.AspNetCore/VerdictProblemDetailsOptions.cs
@@ -19,6 +19,16 @@ public class VerdictProblemDetailsOptions
     public bool IncludeErrorCode { get; set; } = true;
 
     /// <summary>
+    /// Gets error code to HTTP status code mappings for this container.
+    /// </summary>
+    /// <remarks>
+    /// Checked before the shared defaults in <see cref="ErrorStatusCodeMapper"/>,
+    /// so two hosts in one process can map the same code differently. Prefer
+    /// this over the static <c>RegisterMapping</c>, which is process-wide.
+    /// </remarks>
+    public System.Collections.Generic.Dictionary<string, int> StatusCodeMappings { get; } = new();
+
+    /// <summary>
     /// Gets or sets whether to include the error message as the ProblemDetails detail.
     /// If false, a generic message will be used for server errors (5xx).
     /// Default is true.

--- a/tests/Verdict.AspNetCore.Tests/DiScopedConfigurationTests.cs
+++ b/tests/Verdict.AspNetCore.Tests/DiScopedConfigurationTests.cs
@@ -1,0 +1,117 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Verdict.AspNetCore;
+using Xunit;
+
+namespace Verdict.AspNetCore.Tests;
+
+/// <summary>
+/// AddVerdictProblemDetails took an IServiceCollection, registered nothing, and
+/// mutated a process-wide static. Two hosts in one process therefore shared one
+/// configuration and the last registration won. These pin the DI behaviour.
+/// </summary>
+public class DiScopedConfigurationTests : IDisposable
+{
+    // AddVerdictProblemDetails also assigns the process-wide default so the
+    // parameterless extension methods keep working. That leaks between tests,
+    // which is the very hazard these tests exist to document.
+    public void Dispose() => ProblemDetailsFactory.ResetDefaultOptions();
+
+    [Fact]
+    public void AddVerdictProblemDetails_RegistersOptionsInTheContainer()
+    {
+        var services = new ServiceCollection();
+        services.AddVerdictProblemDetails(o => o.IncludeErrorCode = false);
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<VerdictProblemDetailsOptions>>().Value;
+
+        Assert.False(options.IncludeErrorCode);
+    }
+
+    [Fact]
+    public void TwoContainers_DoNotShareConfiguration()
+    {
+        var a = new ServiceCollection();
+        a.AddVerdictProblemDetails(o => o.IncludeErrorMessage = false);
+        var providerA = a.BuildServiceProvider();
+
+        var b = new ServiceCollection();
+        b.AddVerdictProblemDetails(o => o.IncludeErrorMessage = true);
+        var providerB = b.BuildServiceProvider();
+
+        Assert.False(providerA.GetRequiredService<IOptions<VerdictProblemDetailsOptions>>().Value.IncludeErrorMessage);
+        Assert.True(providerB.GetRequiredService<IOptions<VerdictProblemDetailsOptions>>().Value.IncludeErrorMessage);
+    }
+
+    [Fact]
+    public void AddVerdictProblemDetails_RegistersTheStatusCodeMapper()
+    {
+        var services = new ServiceCollection();
+        services.AddVerdictProblemDetails();
+
+        var provider = services.BuildServiceProvider();
+        var mapper = provider.GetRequiredService<IErrorStatusCodeMapper>();
+
+        Assert.Equal(404, mapper.GetStatusCode(new Error("NOT_FOUND", "missing")));
+    }
+
+    [Fact]
+    public void CustomMappings_AreScopedToTheContainer()
+    {
+        var a = new ServiceCollection();
+        a.AddVerdictProblemDetails(o => o.StatusCodeMappings["TENANT_A_ONLY"] = 418);
+        var mapperA = a.BuildServiceProvider().GetRequiredService<IErrorStatusCodeMapper>();
+
+        var b = new ServiceCollection();
+        b.AddVerdictProblemDetails();
+        var mapperB = b.BuildServiceProvider().GetRequiredService<IErrorStatusCodeMapper>();
+
+        Assert.Equal(418, mapperA.GetStatusCode(new Error("TENANT_A_ONLY", "x")));
+        Assert.NotEqual(418, mapperB.GetStatusCode(new Error("TENANT_A_ONLY", "x")));
+    }
+
+    [Fact]
+    public void Mapper_FallsBackForUnknownCodes()
+    {
+        var services = new ServiceCollection();
+        services.AddVerdictProblemDetails();
+        var mapper = services.BuildServiceProvider().GetRequiredService<IErrorStatusCodeMapper>();
+
+        Assert.Equal(400, mapper.GetStatusCode(new Error("SOMETHING_UNMAPPED", "x")));
+    }
+
+    [Fact]
+    public void ProblemDetailsFactory_CanBeResolvedAndUsesContainerOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddVerdictProblemDetails(o => o.IncludeErrorCode = false);
+        var factory = services.BuildServiceProvider().GetRequiredService<IVerdictProblemDetailsFactory>();
+
+        var problem = factory.CreateFromError(new Error("SOME_CODE", "message"), 400);
+
+        Assert.False(problem.Extensions.ContainsKey("errorCode"));
+    }
+
+    /// <summary>
+    /// The static path stays supported so existing code keeps working.
+    /// </summary>
+    [Fact]
+    public void StaticApi_StillWorks()
+    {
+        ProblemDetailsFactory.SetDefaultOptions(new VerdictProblemDetailsOptions { IncludeErrorCode = true });
+
+        var problem = ProblemDetailsFactory.CreateFromError(new Error("STATIC_CODE", "message"), 400);
+
+        Assert.Equal(400, problem.Status);
+    }
+
+    [Fact]
+    public void AddVerdictProblemDetails_NullServices_Throws()
+    {
+        IServiceCollection services = null!;
+
+        Assert.Throws<ArgumentNullException>(() => services.AddVerdictProblemDetails());
+    }
+}


### PR DESCRIPTION
Last item from the audit.

## The problem

`AddVerdictProblemDetails` looked like DI registration and was not:

```csharp
var options = new VerdictProblemDetailsOptions();
configure?.Invoke(options);
ProblemDetailsFactory.SetDefaultOptions(options);   // process-wide static
return services;                                     // untouched
```

It took an `IServiceCollection`, registered **nothing**, mutated a global, and handed the collection back. Two applications hosted in one process shared one configuration and the last registration won.

## It proved itself during the work

Adding a test that called `AddVerdictProblemDetails(o => o.IncludeErrorCode = false)` **broke an unrelated pre-existing test** in the same assembly, because the global leaked across them. That is the production failure mode in miniature.

## The fix

`AddVerdictProblemDetails` now registers:

| Service | Purpose |
|---|---|
| `IOptions<VerdictProblemDetailsOptions>` | the options, per container |
| `IVerdictProblemDetailsFactory` | builds ProblemDetails from that container's options |
| `IErrorStatusCodeMapper` | maps errors to status codes, container mappings first |

Plus `VerdictProblemDetailsOptions.StatusCodeMappings` for per-container mappings, and `ProblemDetailsFactory.ResetDefaultOptions()` so tests can stop leaking.

## Non-breaking

The static path is untouched. `ToActionResult` and `ToHttpResult` are extension methods with no access to DI, so they still read the process-wide defaults, which `AddVerdictProblemDetails` continues to assign. For a single application both paths agree; for multi-host processes you inject the services instead.

584 tests passing, clean build with warnings as errors.