### PR TITLE
fix(extensions): return pooled buffers after enumeration failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `ErrorCollection.Create(IEnumerable<Error>)` now returns its pooled buffer when
+  an `ICollection<Error>` enumerator throws and reports the number of items
+  actually yielded instead of exposing stale pooled slots when `Count`
+  overstates the sequence length.
+
 ## [2.7.0] - 2026-08-07
 
 ### Fixed

--- a/src/Verdict.Extensions/ErrorCollection.cs
+++ b/src/Verdict.Extensions/ErrorCollection.cs
@@ -106,10 +106,15 @@ public readonly struct ErrorCollection : IDisposable
     /// Creates an error collection from an enumerable of errors.
     /// Uses array pooling for better performance.
     /// </summary>
-    public static ErrorCollection Create(IEnumerable<Error> errors)
+    public static ErrorCollection Create(IEnumerable<Error> errors) =>
+        CreateWithPool(errors, ArrayPool<Error>.Shared);
+
+    private static ErrorCollection CreateWithPool(IEnumerable<Error> errors, ArrayPool<Error> pool)
     {
         if (errors == null)
             throw new ArgumentNullException(nameof(errors));
+        if (pool == null)
+            throw new ArgumentNullException(nameof(pool));
 
         // Fast path: if it's already an array, use the array overload
         if (errors is Error[] errorArray)
@@ -118,22 +123,38 @@ public readonly struct ErrorCollection : IDisposable
         // Fast path: if it's a collection, we can get the count without enumerating
         if (errors is ICollection<Error> collection)
         {
-            if (collection.Count == 0)
+            var expectedCount = collection.Count;
+            if (expectedCount == 0)
                 return default;
 
-            var array = ArrayPool<Error>.Shared.Rent(collection.Count);
-            int i = 0;
-            foreach (var error in collection)
+            var array = pool.Rent(expectedCount);
+            try
             {
-                array[i++] = error;
+                int actualCount = 0;
+                foreach (var error in collection)
+                {
+                    array[actualCount++] = error;
+                }
+
+                if (actualCount == 0)
+                {
+                    pool.Return(array, clearArray: true);
+                    return default;
+                }
+
+                return new ErrorCollection(array, actualCount, new RentalTracker(array, pool));
             }
-            return new ErrorCollection(array, collection.Count, new RentalTracker(array));
+            catch
+            {
+                pool.Return(array, clearArray: true);
+                throw;
+            }
         }
 
         // Slow path: unknown size, must enumerate
         // Use a small initial buffer and grow if needed
         const int initialCapacity = 4;
-        var buffer = ArrayPool<Error>.Shared.Rent(initialCapacity);
+        var buffer = pool.Rent(initialCapacity);
         int count = 0;
 
         try
@@ -143,9 +164,9 @@ public readonly struct ErrorCollection : IDisposable
                 if (count == buffer.Length)
                 {
                     // Grow the buffer
-                    var newBuffer = ArrayPool<Error>.Shared.Rent(buffer.Length * 2);
+                    var newBuffer = pool.Rent(buffer.Length * 2);
                     Array.Copy(buffer, newBuffer, count);
-                    ArrayPool<Error>.Shared.Return(buffer, clearArray: true);
+                    pool.Return(buffer, clearArray: true);
                     buffer = newBuffer;
                 }
                 buffer[count++] = error;
@@ -153,15 +174,15 @@ public readonly struct ErrorCollection : IDisposable
 
             if (count == 0)
             {
-                ArrayPool<Error>.Shared.Return(buffer, clearArray: true);
+                pool.Return(buffer, clearArray: true);
                 return default;
             }
 
-            return new ErrorCollection(buffer, count, new RentalTracker(buffer));
+            return new ErrorCollection(buffer, count, new RentalTracker(buffer, pool));
         }
         catch
         {
-            ArrayPool<Error>.Shared.Return(buffer, clearArray: true);
+            pool.Return(buffer, clearArray: true);
             throw;
         }
     }
@@ -232,10 +253,12 @@ public readonly struct ErrorCollection : IDisposable
     internal sealed class RentalTracker
     {
         private Error[]? _array;
+        private readonly ArrayPool<Error> _pool;
 
-        internal RentalTracker(Error[] array)
+        internal RentalTracker(Error[] array, ArrayPool<Error> pool)
         {
             _array = array;
+            _pool = pool;
         }
 
         internal bool IsDisposed => Volatile.Read(ref _array) is null;
@@ -245,7 +268,7 @@ public readonly struct ErrorCollection : IDisposable
             var array = Interlocked.Exchange(ref _array, null);
             if (array != null)
             {
-                ArrayPool<Error>.Shared.Return(array, clearArray: true);
+                _pool.Return(array, clearArray: true);
             }
         }
     }

--- a/tests/Verdict.Extensions.Tests/ErrorCollectionDisposalTests.cs
+++ b/tests/Verdict.Extensions.Tests/ErrorCollectionDisposalTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Buffers;
+using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using Verdict.Extensions;
 using Xunit;
 
@@ -106,6 +108,46 @@ public class ErrorCollectionDisposalTests
     }
 
     [Fact]
+    public void Create_WhenCollectionEnumerationThrows_ReturnsClearedBufferToPool()
+    {
+        var pool = new TrackingArrayPool<Error>(4);
+        var errors = new MisreportingCollection(
+            reportedCount: 4,
+            throwAfterFirst: true,
+            new Error("SENSITIVE", "must be cleared"));
+
+        var createWithPool = typeof(ErrorCollection).GetMethod(
+            "CreateWithPool",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(createWithPool);
+        var invocation = Assert.Throws<TargetInvocationException>(() =>
+        {
+            createWithPool.Invoke(null, new object[] { errors, pool });
+        });
+        Assert.IsType<InvalidOperationException>(invocation.InnerException);
+
+        Assert.Equal(1, pool.RentCount);
+        Assert.Equal(1, pool.ReturnCount);
+        Assert.All(pool.Buffer, error => Assert.Equal(default, error));
+    }
+
+    [Fact]
+    public void Create_WhenCollectionYieldsFewerItems_UsesActualCount()
+    {
+        var errors = new MisreportingCollection(
+            reportedCount: 4,
+            throwAfterFirst: false,
+            new Error("A", "one"),
+            new Error("B", "two"));
+
+        using var collection = ErrorCollection.Create(errors);
+
+        Assert.Equal(2, collection.Count);
+        Assert.Equal(new[] { "A", "B" }, Array.ConvertAll(collection.ToArray(), error => error.Code));
+    }
+
+    [Fact]
     public void NonPooledCollection_RemainsUsableAfterDispose()
     {
         // Create(Error) and Create(params Error[]) allocate their own array and
@@ -140,5 +182,72 @@ public class ErrorCollectionDisposalTests
         }
 
         Assert.Throws<ObjectDisposedException>(() => escaped[0]);
+    }
+
+    private sealed class MisreportingCollection : ICollection<Error>
+    {
+        private readonly Error[] _errors;
+        private readonly bool _throwAfterFirst;
+
+        internal MisreportingCollection(int reportedCount, bool throwAfterFirst, params Error[] errors)
+        {
+            Count = reportedCount;
+            _throwAfterFirst = throwAfterFirst;
+            _errors = errors;
+        }
+
+        public int Count { get; }
+        public bool IsReadOnly => true;
+
+        public IEnumerator<Error> GetEnumerator()
+        {
+            foreach (var error in _errors)
+            {
+                yield return error;
+                if (_throwAfterFirst)
+                {
+                    throw new InvalidOperationException("enumeration failed");
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public void Add(Error item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Contains(Error item) => Array.IndexOf(_errors, item) >= 0;
+        public void CopyTo(Error[] array, int arrayIndex) => _errors.CopyTo(array, arrayIndex);
+        public bool Remove(Error item) => throw new NotSupportedException();
+    }
+
+    private sealed class TrackingArrayPool<T> : ArrayPool<T>
+    {
+        internal TrackingArrayPool(int capacity)
+        {
+            Buffer = new T[capacity];
+        }
+
+        internal T[] Buffer { get; }
+        internal int RentCount { get; private set; }
+        internal int ReturnCount { get; private set; }
+
+        public override T[] Rent(int minimumLength)
+        {
+            if (minimumLength > Buffer.Length || RentCount != ReturnCount)
+                throw new InvalidOperationException("Tracking pool cannot satisfy the rental.");
+
+            RentCount++;
+            return Buffer;
+        }
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            if (!ReferenceEquals(array, Buffer) || ReturnCount == RentCount)
+                throw new InvalidOperationException("Tracking pool received an unknown buffer.");
+
+            if (clearArray)
+                Array.Clear(array, 0, array.Length);
+
+            ReturnCount++;
+        }
     }
 }


### PR DESCRIPTION
## What this changes

Return the rented `ErrorCollection` buffer when an `ICollection<Error>` enumerator throws, and use the number of items actually yielded when `Count` overstates the sequence length. A private pool seam makes the exception-path ownership test deterministic without changing the public API.

## Related issue

Fixes #24.

## Checklist

- [x] A test fails without this change
- [ ] `dotnet test Verdict.sln` passes locally (one unrelated existing `ProblemDetailsFactory` test races with tests that mutate process-wide defaults when the assembly runs in parallel; it passes in isolation)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`

## Verification

- [x] `dotnet build Verdict.sln --configuration Release` (0 errors)
- [x] `Verdict.Extensions.Tests` (145 passed)
- [x] `Verdict.ApiApproval.Tests` (8 passed; public API unchanged)
- [x] Solution tests excluding the pre-existing isolation failure (600 passed), followed by that test alone (1 passed)
- [x] Scoped `dotnet format ... --verify-no-changes` (0 files changed)
- [x] `git diff --check`

## Public API and performance

The public API is unchanged. The new helper is private, and the normal path still uses `ArrayPool<Error>.Shared`; no relevant benchmark exists in the repository.

Disclosure: OpenAI Codex assisted with implementation and tests. The exact revised patch was independently reviewed by Google Antigravity and validated locally; no AI model is credited as a legal author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error collection handling when enumerating collections fails partway through.
  * Correctly tracks the number of items actually read, even when a collection reports an inaccurate count.
  * Ensured temporary data is properly cleared and returned after successful or failed operations.

* **Documentation**
  * Added an unreleased changelog entry describing these reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->