### PR TITLE
serialise the tests that share ProblemDetailsFactory's static defaults

### DIFF
--- a/tests/Verdict.AspNetCore.Tests/DiScopedConfigurationTests.cs
+++ b/tests/Verdict.AspNetCore.Tests/DiScopedConfigurationTests.cs
@@ -11,6 +11,7 @@ namespace Verdict.AspNetCore.Tests;
 /// mutated a process-wide static. Two hosts in one process therefore shared one
 /// configuration and the last registration won. These pin the DI behaviour.
 /// </summary>
+[Collection(ProblemDetailsStaticCollection.Name)]
 public class DiScopedConfigurationTests : IDisposable
 {
     // AddVerdictProblemDetails also assigns the process-wide default so the

--- a/tests/Verdict.AspNetCore.Tests/ProblemDetailsFactoryTests.cs
+++ b/tests/Verdict.AspNetCore.Tests/ProblemDetailsFactoryTests.cs
@@ -8,6 +8,7 @@ using Verdict.Extensions;
 
 namespace Verdict.AspNetCore.Tests;
 
+[Collection(ProblemDetailsStaticCollection.Name)]
 public class ProblemDetailsFactoryTests
 {
     [Fact]

--- a/tests/Verdict.AspNetCore.Tests/ProblemDetailsStaticCollection.cs
+++ b/tests/Verdict.AspNetCore.Tests/ProblemDetailsStaticCollection.cs
@@ -1,0 +1,27 @@
+using Xunit;
+
+namespace Verdict.AspNetCore.Tests;
+
+/// <summary>
+/// Serialises every test class that touches <c>ProblemDetailsFactory</c>'s process-wide default
+/// options.
+///
+/// The parameterless <c>CreateFromError</c> overloads read a static, and <c>SetDefaultOptions</c>
+/// and <c>AddVerdictProblemDetails</c> both write it. xUnit runs test classes in parallel by
+/// default, so a class mutating that static can run at the same instant as a class reading it, and
+/// per-class cleanup cannot help: the damage happens while both are still running.
+///
+/// That is what made #33 look intermittent. It is not flaky in the usual sense, it is
+/// order-dependent: it passes on an incremental build and fails after a clean one, because a clean
+/// build changes assembly and collection ordering and therefore which class ran last.
+///
+/// A collection is the honest fix rather than a workaround. The static is real shared state that
+/// exists for backwards compatibility, so tests covering it genuinely cannot run concurrently.
+/// The container-scoped API added in 2.7.0 is the way out for consumers; these tests still have to
+/// cover the static path while it ships.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ProblemDetailsStaticCollection
+{
+    public const string Name = "ProblemDetailsFactory static defaults";
+}

--- a/tests/Verdict.AspNetCore.Tests/ProductionReadinessTests.cs
+++ b/tests/Verdict.AspNetCore.Tests/ProductionReadinessTests.cs
@@ -15,8 +15,14 @@ namespace Verdict.AspNetCore.Tests;
 /// Production readiness tests for ASP.NET Core integration.
 /// Tests thread-safety, concurrent access, and edge cases.
 /// </summary>
-public class ProductionReadinessTests
+[Collection(ProblemDetailsStaticCollection.Name)]
+public class ProductionReadinessTests : IDisposable
 {
+    // Several tests here write ProblemDetailsFactory's process-wide default options. Restoring on
+    // teardown rather than in each test means a new test cannot forget: the leak in #33 came from
+    // exactly one test that mutated and did not restore.
+    public void Dispose() => ProblemDetailsFactory.ResetDefaultOptions();
+
     #region ErrorStatusCodeMapper Thread Safety
 
     [Fact]
@@ -141,6 +147,11 @@ public class ProductionReadinessTests
 
         await Task.WhenAll(writeTasks);
         var results = await Task.WhenAll(readTasks);
+
+        // Restored here as well as in Dispose. This test is the one that leaves a
+        // NON-DETERMINISTIC value behind, since which of the two option objects lands last is a
+        // race by design, so it should not rely on teardown ordering to clean up after itself.
+        ProblemDetailsFactory.ResetDefaultOptions();
 
         // Assert - no exceptions, all valid ProblemDetails
         results.Should().AllSatisfy(pd =>

--- a/tests/Verdict.AspNetCore.Tests/VerdictProblemDetailsOptionsTests.cs
+++ b/tests/Verdict.AspNetCore.Tests/VerdictProblemDetailsOptionsTests.cs
@@ -7,6 +7,7 @@ namespace Verdict.AspNetCore.Tests;
 /// <summary>
 /// Tests for VerdictProblemDetailsOptions configuration.
 /// </summary>
+[Collection(ProblemDetailsStaticCollection.Name)]
 public class VerdictProblemDetailsOptionsTests
 {
     [Fact]

--- a/tests/Verdict.AspNetCore.Tests/VerdictProblemDetailsOptionsTests.cs
+++ b/tests/Verdict.AspNetCore.Tests/VerdictProblemDetailsOptionsTests.cs
@@ -8,8 +8,14 @@ namespace Verdict.AspNetCore.Tests;
 /// Tests for VerdictProblemDetailsOptions configuration.
 /// </summary>
 [Collection(ProblemDetailsStaticCollection.Name)]
-public class VerdictProblemDetailsOptionsTests
+public class VerdictProblemDetailsOptionsTests : IDisposable
 {
+    // Teardown rather than an inline cleanup line. An inline restore only runs when the
+    // assertions above it pass, so a failing test used to leave the custom defaults behind.
+    // That mattered less while classes raced; now that this collection serialises them, leaked
+    // state reaches the next class in the collection deterministically.
+    public void Dispose() => ProblemDetailsFactory.ResetDefaultOptions();
+
     [Fact]
     public void CreateFromError_WithDefaultOptions_ShouldIncludeErrorCode()
     {
@@ -175,7 +181,6 @@ public class VerdictProblemDetailsOptionsTests
         // Assert
         problemDetails.Extensions.Should().NotContainKey("errorCode");
 
-        // Cleanup - Reset to default
-        ProblemDetailsFactory.SetDefaultOptions(new VerdictProblemDetailsOptions());
+        // No inline cleanup: Dispose restores the static whether or not this assertion holds.
     }
 }


### PR DESCRIPTION
Fixes #33.

## What was wrong

`ProblemDetailsFactory`'s parameterless overloads read a process-wide static. `SetDefaultOptions` and `AddVerdictProblemDetails` both write it. **xUnit runs test classes in parallel by default**, and four classes in this assembly touch that static:

- `ProductionReadinessTests` writes it, in a loop, alternating `IncludeErrorCode` true and false
- `VerdictProblemDetailsOptionsTests` writes it
- `DiScopedConfigurationTests` writes it via `AddVerdictProblemDetails`
- `ProblemDetailsFactoryTests` **reads** it

So a class mutating the static could run at the same instant as the class reading it.

## Why it looked flaky and was not

It is order-dependent, not random: it **passes on an incremental build and fails after `dotnet clean`**, because a clean build changes assembly and collection ordering and therefore which class runs when.

That is what made it hard to place. I hit it while preparing 2.8.0, spent a while suspecting my own version bump, and filed a duplicate issue before finding this one. @snowyukitty had already diagnosed it correctly on 15 August, in the checklist of #34, and left the box unticked rather than claiming a green run.

## The fix, and which half actually does the work

A `[CollectionDefinition]` puts all four classes in one xUnit collection so they cannot run concurrently, plus `ProductionReadinessTests` now restores the static on teardown and immediately after the concurrency test.

**Mutation-tested in both directions, which changed what I would have claimed:**

| Mutation | Result |
|---|---|
| Remove the restore, keep the collection | **still passes** |
| Keep the restore, remove the collection from the reader | **fails, then passes** across two runs |

So the **collection is load-bearing** and the restore is defensive depth. That makes sense once stated: the restore runs at class teardown, but the damage happens *during* execution while both classes are live. Cleanup after the fact cannot win a race that is already lost.

The restore is still worth keeping, since it stops a future test in that class leaking into a later one, but I would have described this fix wrongly if I had only run the happy path.

## Verification

- **601 tests pass** across all nine projects on a clean solution build.
- `Verdict.AspNetCore.Tests` passes 63/63 on **three consecutive clean builds**, which is the condition that used to flip it.
- Public API unchanged: 8 API approval tests pass.

## Note on the underlying design

The collection is the honest fix rather than a workaround. The static is real shared state kept for backwards compatibility, so tests covering it genuinely cannot run concurrently. 2.7.0 added container-scoped configuration as the way out for consumers; these tests still have to cover the static path for as long as it ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved isolation for problem-details configuration scenarios.
  * Serialized related tests to prevent interference from shared settings.
  * Added cleanup and explicit resets to ensure consistent results across test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->