### PR TITLE
release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-08-17
+
+### Added
+
+- **`net8.0` alongside `netstandard2.0` on every package.** Purely additive:
+  existing consumers resolve exactly as before, and .NET 8 consumers now get a
+  target the trimming and AOT analyzers can actually see, so a trim warning
+  surfaces at build time rather than as a missing method at run time.
+- **The zero-allocation promise is now enforced by a test, not asserted in the
+  README.** `AllocationTests` measures allocations directly on the success path.
+  Until now a contributor could break the reason to use this library without
+  breaking a single behavioural test: add a field that boxes, capture a variable
+  in a lambda, return an interface instead of the struct, and everything still
+  went green while the benchmark quietly regressed.
+- **The public API surface of all eight packages is pinned.** Any change to a
+  signature, an accessibility, a base type or a default parameter now fails a
+  test with a readable diff, and the failure message states the versioning rule
+  it implies.
+
+### Changed
+
+- Nothing behavioural. No API was added, removed or altered in this release; the
+  approval snapshots are unchanged from 2.7.0.
+
 ## [2.7.0] - 2026-08-07
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Single source of truth for the release version. The publish workflow
          reads this rather than taking a hand-typed input, so what shipped is
          always recorded in git. -->
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- Everything below applies only to the shipping libraries. -->


### PR DESCRIPTION
Version bump and changelog for 2.8.0. No source changes beyond what is already on master.

**Minor, not patch:** `netstandard2.0` becomes `netstandard2.0;net8.0` on every package. Purely additive, so existing consumers resolve exactly as before.

Contents:

- @snowyukitty's pooled-buffer fix (#24, #34), which also corrects a second bug the issue did not ask for: using the count actually yielded rather than `Count`, so a collection that overstates its length no longer exposes stale pooled slots.
- The static-options test isolation fix (#33, #36).
- The zero-allocation gate, the API approval snapshots, and net8.0 targets.

601 tests pass on a clean solution build. All 8 packages pack at 2.8.0 carrying both target frameworks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package support for .NET 8.0.
  * Added allocation testing and public API approval tests.

* **Bug Fixes**
  * Improved pooled-buffer cleanup.
  * Improved test isolation.

* **Release**
  * Updated the release version to 2.8.0, dated August 18, 2026.
  * Confirmed no public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->